### PR TITLE
fix: showing chapters from previous video

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -48,7 +48,7 @@ export const useSummarize = (
 ) => {
   const vid = parseVid(pageUrl)
   const chapters = pageChapters ?? []
-  log(TAG, `useSummarize, vid=${vid}, toggled=${toggled}`)
+  log(TAG, `useSummarize, vid=${vid}, toggled=${toggled}, chapters.length=${chapters.length}, last_chapter="${chapters[chapters.length - 1]?.title}"`)
 
   // Allow resummarize when `toggled` changed.
   return useSWRSubscription(


### PR DESCRIPTION
When summarizing one video and then switching to another, it would display the old chapters for the new video.

The chapters would also get stored in the database like this.

Following advice from
https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes